### PR TITLE
adding language support package for Atom editor

### DIFF
--- a/tools/index.md
+++ b/tools/index.md
@@ -59,6 +59,7 @@ update: "tools/index.md"
 * [closure snippets](https://github.com/closureplease/sublime-google-closure-snippets#readme) Sublime Package with Closure snippets.
 * [Closure IDE for Eclipse](http://digi-area.com/ClosureIDE/) A commercial product that provides extensive GUI tools for Closure Compiler, Closure Templates and Closure Stylesheets.
 * [SoyTemplate.tmbundle](https://github.com/anvie/SoyTemplate) A TextMate Bundle & Sublime Text 2 Package for Google Closure Templates.
+* [Soy for Atom](https://atom.io/packages/language-soy) An Atom Editor package for Closure Templates.
 
 ## Documentation Generators
 


### PR DESCRIPTION
I've created a package for GitHub's Atom editor to support Soy templates.  Currently it just provides syntax highlighting, but I plan on adding a configurable auto-build and snippets/autocompletion for commands and the jsDoc comment format.
