### PR TITLE
Updating from code.google.com to github.com

### DIFF
--- a/externs/externs.json
+++ b/externs/externs.json
@@ -4,7 +4,7 @@
             "libraryUrl": "http://angularjs.org/",
             "versions": [{
                     "filename": "angular.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/angular.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular.js",
                     "libraryVer": "1.0.5"
                 }
             ]
@@ -13,7 +13,7 @@
             "libraryUrl": "https://developers.facebook.com/docs/reference/javascript/",
             "versions": [{
                     "filename": "facebook_javascript_sdk.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/facebook_javascript_sdk.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/facebook_javascript_sdk.js",
                     "libraryVer": "-"
                 }
             ]
@@ -22,7 +22,7 @@
             "libraryUrl": "http://underscorejs.org/",
             "versions": [{
                     "filename": "underscore-1.3.1.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/underscore-1.3.1.js",
+                    "url": "hhttps://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/underscore-1.3.1.js",
                     "libraryVer": "1.3.1"
                 }
             ]
@@ -31,7 +31,7 @@
             "libraryUrl": "http://www.json.org/",
             "versions": [{
                     "filename": "json.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/json.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/json.js",
                     "libraryVer": "2.0"
                 }
             ]
@@ -49,35 +49,35 @@
             "libraryUrl": "http://api.jquery.com/",
             "versions": [{
                     "filename": "jquery-1.3.2.externs.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.3.2.externs.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.3.2.externs.js",
                     "libraryVer": "1.3.2"
                 }, {
                     "filename": "jquery-1.4.3.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.4.3.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.4.3.js",
                     "libraryVer": "1.4.3"
                 }, {
                     "filename": "jquery-1.4.4.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.4.4.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.4.4.js",
                     "libraryVer": "1.4.4"
                 }, {
                     "filename": "jquery-1.5.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.5.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.5.js",
                     "libraryVer": "1.5"
                 }, {
                     "filename": "jquery-1.6.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.6.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.6.js",
                     "libraryVer": "1.6"
                 }, {
                     "filename": "jquery-1.7.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.7.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.7.js",
                     "libraryVer": "1.7"
                 }, {
                     "filename": "jquery-1.8.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.8.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.8.js",
                     "libraryVer": "1.8"
                 }, {
                     "filename": "jquery-1.9.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/jquery-1.9.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.9.js",
                     "libraryVer": "1.9"
                 }
             ]
@@ -86,7 +86,7 @@
             "libraryUrl": "http://www.w3.org/TR/webaudio/",
             "versions": [{
                     "filename": "w3c_audio.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_audio.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_audio.js",
                     "libraryVer": "-"
                 }
             ]
@@ -95,7 +95,7 @@
             "libraryUrl": "http://www.w3.org/TR/eventsource/",
             "versions": [{
                     "filename": "w3c_eventsource.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_eventsource.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_eventsource.js",
                     "libraryVer": "-"
                 }
             ]
@@ -104,7 +104,7 @@
             "libraryUrl": "https://developer.mozilla.org/en-US/docs/DOM/File",
             "versions": [{
                     "filename": "fileapi_synchronous.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/fileapi_synchronous.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/fileapi_synchronous.js",
                     "libraryVer": "-"
                 }
             ]
@@ -113,7 +113,7 @@
             "libraryUrl": "http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html",
             "versions": [{
                     "filename": "fullscreen.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/fullscreen.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/fullscreen.js",
                     "libraryVer": "-"
                 }
             ]
@@ -122,7 +122,7 @@
             "libraryUrl": "http://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html",
             "versions": [{
                     "filename": "mediasource.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/mediasource.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/mediasource.js",
                     "libraryVer": "-"
                 }
             ]
@@ -131,7 +131,7 @@
             "libraryUrl": "http://www.w3.org/TR/gamepad/",
             "versions": [{
                     "filename": "w3c_gamepad.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_gamepad.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_gamepad.js",
                     "libraryVer": "-"
                 }
             ]
@@ -140,7 +140,7 @@
             "libraryUrl": "http://dev.w3.org/2011/webrtc/editor/webrtc.html",
             "versions": [{
                     "filename": "w3c_rtc.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_rtc.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_rtc.js",
                     "libraryVer": "-"
                 }
             ]
@@ -149,7 +149,7 @@
             "libraryUrl": "http://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html",
             "versions": [{
                     "filename": "w3c_speech.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_speech.js",
+                    "url": "hhttps://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_speech.js",
                     "libraryVer": "-"
                 }
             ]
@@ -158,7 +158,7 @@
             "libraryUrl": "http://dvcs.w3.org/hg/web-intents/raw-file/tip/spec/Overview.html",
             "versions": [{
                     "filename": "w3c_web_intents.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/w3c_web_intents.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/w3c_web_intents.js",
                     "libraryVer": "-"
                 }
             ]
@@ -167,7 +167,7 @@
             "libraryUrl": "https://code.google.com/apis/+1button/#jsapi",
             "versions": [{
                     "filename": "plusone.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/plusone.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/plusone.js",
                     "libraryVer": "-"
                 }
             ]
@@ -176,7 +176,7 @@
             "libraryUrl": "http://code.google.com/apis/youtube/js_api_reference.html",
             "versions": [{
                     "filename": "youtubeplayer.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/youtubeplayer.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/youtubeplayer.js",
                     "libraryVer": "-"
                 }
             ]
@@ -185,7 +185,7 @@
             "libraryUrl": "http://code.google.com/apis/youtube/iframe_api_reference.html",
             "versions": [{
                     "filename": "google_youtube_iframe.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/google_youtube_iframe.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_youtube_iframe.js",
                     "libraryVer": "-"
                 }
             ]
@@ -194,7 +194,7 @@
             "libraryUrl": "http://code.google.com/apis/maps/documentation/javascript/v2/reference.html",
             "versions": [{
                     "filename": "google_maps_api_v2.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/google_maps_api_v2.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_maps_api_v2.js",
                     "libraryVer": "2.0.0"
                 }
             ]
@@ -203,51 +203,71 @@
             "libraryUrl": "http://code.google.com/apis/maps/documentation/javascript/reference.html",
             "versions": [{
                     "filename": "google_maps_api_v3.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3.js",
                     "libraryVer": "3.0"
                 }, {
                     "filename": "google_maps_api_v3_3.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_3.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_3.js",
                     "libraryVer": "3.3"
                 }, {
                     "filename": "google_maps_api_v3_4.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_4.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_4.js",
                     "libraryVer": "3.4"
                 }, {
                     "filename": "google_maps_api_v3_5.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_5.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_5.js",
                     "libraryVer": "3.5"
                 }, {
                     "filename": "google_maps_api_v3_6.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_6.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_6.js",
                     "libraryVer": "3.6"
                 }, {
                     "filename": "google_maps_api_v3_7.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_7.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_7.js",
                     "libraryVer": "3.7"
                 }, {
                     "filename": "google_maps_api_v3_8.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_8.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_8.js",
                     "libraryVer": "3.8"
                 }, {
                     "filename": "google_maps_api_v3_9.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_9.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_9.js",
                     "libraryVer": "3.9"
                 }, {
                     "filename": "google_maps_api_v3_10.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_10.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_10.js",
                     "libraryVer": "3.10"
                 }, {
                     "filename": "google_maps_api_v3_11.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_11.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_11.js",
                     "libraryVer": "3.11"
                 }, {
                     "filename": "google_maps_api_v3_12.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_12.js",
                     "libraryVer": "3.12"
                 }, {
+                    "filename": "google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_13.js",
+                    "libraryVer": "3.13"
+                }, {
+                    "filename": "google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_14.js",
+                    "libraryVer": "3.14"
+                }, {
+                    "filename": "google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_15.js",
+                    "libraryVer": "3.15"
+                }, {
+                    "filename": "google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_16.js",
+                    "libraryVer": "3.16"
+                }, {
+                    "filename": "google_maps_api_v3_12.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_17.js",
+                    "libraryVer": "3.17"
+                }, {
                     "filename": "google_maps_api_v3_exp.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/maps/google_maps_api_v3_exp.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3_exp.js",
                     "libraryVer": "3.exp"
                 }
             ]
@@ -256,7 +276,7 @@
             "libraryUrl": "http://code.google.com/intl/en/apis/analytics/docs/gaJS/gaJSApi.html",
             "versions": [{
                     "filename": "google_analytics_api.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/google_analytics_api.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_analytics_api.js",
                     "libraryVer": "-"
                 }
             ]
@@ -265,7 +285,7 @@
             "libraryUrl": "https://developers.google.com/chart/interactive/docs/reference",
             "versions": [{
                     "filename": "google_visualization_api.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/google_visualization_api.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_visualization_api.js",
                     "libraryVer": "-"
                 }
             ]
@@ -274,7 +294,7 @@
             "libraryUrl": "http://trac.webkit.org/browser/trunk/WebCore/page/Console.idl",
             "versions": [{
                     "filename": "webkit_console.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/webkit_console.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/webkit_console.js",
                     "libraryVer": "-"
                 }
             ]
@@ -283,7 +303,7 @@
             "libraryUrl": "http://code.google.com/apis/ajax/documentation/",
             "versions": [{
                     "filename": "google_loader_api.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/google_loader_api.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_loader_api.js",
                     "libraryVer": "-"
                 }
             ]
@@ -292,7 +312,7 @@
             "libraryUrl": "http://docs.closure-library.googlecode.com/git/class_goog_ui_Container.html",
             "versions": [{
                     "filename": "google.container.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/google.container.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/google.container.js",
                     "libraryVer": "-"
                 }
             ]
@@ -301,7 +321,7 @@
             "libraryUrl": "https://chrome.google.com/webstore/category/extensions",
             "versions": [{
                     "filename": "chrome_extensions.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/chrome_extensions.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/chrome_extensions.js",
                     "libraryVer": "-"
                 }
             ]
@@ -310,7 +330,7 @@
             "libraryUrl": "http://code.google.com/apis/gadgets/docs/oauth.html",
             "versions": [{
                     "filename": "oauth.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/oauth.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/oauth.js",
                     "libraryVer": "-"
                 }
             ]
@@ -319,7 +339,7 @@
             "libraryUrl": "http://code.google.com/apis/gadgets/docs/oauth.html",
             "versions": [{
                     "filename": "oauth2.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/oauth2.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/oauth2.js",
                     "libraryVer": "-"
                 }
             ]
@@ -337,7 +357,7 @@
             "libraryUrl": "http://code.google.com/apis/gadgets/docs/reference/",
             "versions": [{
                     "filename": "opensocial.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/opensocial.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/opensocial.js",
                     "libraryVer": "-"
                 }
             ]
@@ -346,7 +366,7 @@
             "libraryUrl": "http://incubator.apache.org/shindig/shindig-1.1.x/shindig-features/jsdoc",
             "versions": [{
                     "filename": "shindig.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/api/gadgets/shindig.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/api/gadgets/shindig.js",
                     "libraryVer": "1.1.x"
                 }
             ]
@@ -355,7 +375,7 @@
             "libraryUrl": "http://msdn.microsoft.com/en-us/library/bb980101(v=VS.95).aspx",
             "versions": [{
                     "filename": "silverlight.js",
-                    "url": "https://code.google.com/p/closure-compiler/source/browse/contrib/externs/silverlight.js",
+                    "url": "https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/silverlight.js",
                     "libraryVer": "-"
                 }
             ]


### PR DESCRIPTION
Google closure compiler moved to github. See http://closuretools.blogspot.com.au/2014/06/call-of-octocat-from-google-code-to.html for more details.
